### PR TITLE
Don't add login_hint if sid is present

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -13,7 +13,7 @@ chrome.webRequest.onBeforeRequest.addListener(function(details){
       var url = new URL(details.url);        
 
       var search = url.searchParams;
-      if(!search.has("login_hint")){
+      if(!search.has("login_hint") && !search.has("sid")){
          search.append("login_hint", email);
    
          return { redirectUrl: url.toString()};


### PR DESCRIPTION
Fixes #2; AAD will return an error if both login_hint and sid are present in a URL, so don't add login_hint if sid is already on the URL. Tested on both a website (Azure Data Explorer) that would error before (it now silently logs in, it looks like), and a site that used to work, and both seem to be fine. 